### PR TITLE
Treat X and non-X models as the same device (integration startup phase)

### DIFF
--- a/custom_components/solix_ble/__init__.py
+++ b/custom_components/solix_ble/__init__.py
@@ -42,9 +42,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolixBLEConfigEntry) -> 
         )
 
     device = None
-    if ble_device.name == "Anker SOLIX C300X":
+    if "Anker SOLIX C300" in ble_device.name:
         device = C300(ble_device)
-    elif ble_device.name == "Anker SOLIX C1000":
+    elif "Anker SOLIX C1000" in ble_device.name:
         device = C1000(ble_device)
     else:
         _LOGGER.warning(


### PR DESCRIPTION
This mirrors the change in commit 97cdc21

Without this change, the configuration flow completes for the affected models, but the integration will only create a generic device entry.