### PR TITLE
Use experimental SolixBLE with service discovery cache enabled

### DIFF
--- a/custom_components/solix_ble/manifest.json
+++ b/custom_components/solix_ble/manifest.json
@@ -14,7 +14,7 @@
     "integration_type": "device",
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/flip-dots/HaSolixBLE/issues",
-    "requirements": ["SolixBLE==3.8.0"],
+    "requirements": ["SolixBLE@git+https://github.com/flip-dots/SolixBLE@60c6679d5e398a18ded159e7565bc1e85346f5b2"],
     "loggers": ["bleak", "SolixBLE"],
     "version": "3.5.0"
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,4 +6,4 @@ pytest-cov
 aiousbwatcher
 ruff
 mypy
-SolixBLE==3.8.0
+SolixBLE@git+https://github.com/flip-dots/SolixBLE@60c6679d5e398a18ded159e7565bc1e85346f5b2


### PR DESCRIPTION
This uses a version of SolixBLE where the use_services_cache flag passed to Bleak when initialising a device is the default value instead of disabled. This might fix the issue raised [here](https://github.com/flip-dots/HaSolixBLE/issues/3#issuecomment-4880601952).