### PR TITLE
Add control for C1000G2

### DIFF
--- a/custom_components/solix_ble/switch.py
+++ b/custom_components/solix_ble/switch.py
@@ -9,7 +9,15 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from SolixBLE import C300, C800, C1000, PortStatus, PrimeCharger160w, SolixBLEDevice
+from SolixBLE import (
+    C300,
+    C800,
+    C1000,
+    C1000G2,
+    PortStatus,
+    PrimeCharger160w,
+    SolixBLEDevice,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +37,7 @@ async def async_setup_entry(
     switches: list[SolixSwitchEntity] = []
 
     # Support for AC output switch with status
-    if type(device) in [C300, C800, C1000]:
+    if type(device) in [C300, C800, C1000, C1000G2]:
         switches.append(
             SolixSwitchEntity(
                 device,
@@ -42,7 +50,7 @@ async def async_setup_entry(
         )
 
     # Support for DC output switch with status
-    if type(device) in [C300]:
+    if type(device) in [C300, C1000G2]:
         switches.append(
             SolixSwitchEntity(
                 device,

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -19,7 +19,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from SolixBLE import PortStatus, SolixBLEDevice
-from sqlalchemy import union
 
 from custom_components.solix_ble.const import DOMAIN
 
@@ -27,6 +26,7 @@ from . import (
     MOCK_C300_DETAILS,
     MOCK_C800_DETAILS,
     MOCK_C1000_DETAILS,
+    MOCK_C1000G2_DETAILS,
     MOCK_PRIME_160_DETAILS,
     MockDeviceDetails,
 )
@@ -133,6 +133,28 @@ from . import (
             "turn_display_off",
             None,
             id="c1000_display",
+        ),
+        pytest.param(
+            MOCK_C1000G2_DETAILS,
+            MOCK_C1000G2_DETAILS,
+            "C1000G2",
+            "ac_output",
+            "ac_output",
+            "turn_ac_on",
+            "turn_ac_off",
+            (PortStatus.NOT_CONNECTED, PortStatus.OUTPUT, PortStatus.NOT_CONNECTED),
+            id="c100g2_ac",
+        ),
+        pytest.param(
+            MOCK_C1000G2_DETAILS,
+            MOCK_C1000G2_DETAILS,
+            "C1000G2",
+            "dc_output",
+            "dc_output",
+            "turn_dc_on",
+            "turn_dc_off",
+            (PortStatus.NOT_CONNECTED, PortStatus.OUTPUT, PortStatus.NOT_CONNECTED),
+            id="c1000g2_dc",
         ),
         pytest.param(
             MOCK_PRIME_160_DETAILS,


### PR DESCRIPTION
This PR adds support for controlling the AC/DC outputs of the C1000G2 thanks to work by @lukasbraach.