### PR TITLE
Use latest SolixBLE

### DIFF
--- a/custom_components/solix_ble/manifest.json
+++ b/custom_components/solix_ble/manifest.json
@@ -14,7 +14,7 @@
     "integration_type": "device",
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/flip-dots/HaSolixBLE/issues",
-    "requirements": ["SolixBLE==3.8.0"],
+    "requirements": ["SolixBLE==3.9.0"],
     "loggers": ["bleak", "SolixBLE"],
     "version": "3.5.0"
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,4 +6,4 @@ pytest-cov
 aiousbwatcher
 ruff
 mypy
-SolixBLE==3.8.0
+SolixBLE==3.9.0


### PR DESCRIPTION
Use the latest version of SolixBLE which adds support for the MagGo 3-in-1, F2600, and improves support for the 250w desktop charger, C1000, and C300DC.