### PR TITLE
Add C1000(X) DC sensors

### DIFF
--- a/custom_components/solix_ble/sensor.py
+++ b/custom_components/solix_ble/sensor.py
@@ -345,7 +345,7 @@ async def async_setup_entry(
         )
 
     # DC power out
-    if type(device) in [C300, C300DC, C1000G2]:
+    if type(device) in [C300, C300DC, C1000, C1000G2]:
         sensors.append(
             SolixSensorEntity(
                 device,
@@ -371,8 +371,7 @@ async def async_setup_entry(
         )
 
     # DC power out status
-    # TODO: Reenable for C1000 when underlying library fixes
-    if type(device) in [C300, C1000G2, F3800]:
+    if type(device) in [C300, C1000, C1000G2, F3800]:
         sensors.append(
             SolixSensorEntity(
                 device,

--- a/custom_components/solix_ble/switch.py
+++ b/custom_components/solix_ble/switch.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
         )
 
     # Support for DC output switch with status
-    if type(device) in [C300, C1000G2]:
+    if type(device) in [C300, C1000, C1000G2]:
         switches.append(
             SolixSwitchEntity(
                 device,
@@ -64,7 +64,7 @@ async def async_setup_entry(
         )
 
     # Support for DC output switch without status
-    if type(device) in [C800, C1000]:
+    if type(device) in [C800]:
         switches.append(
             SolixSwitchEntity(
                 device,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -308,12 +308,14 @@ MOCK_C1000_TEST_DATA = {
     "usb_c2_power": 6,
     "usb_a1_power": 7,
     "usb_a2_power": 8,
+    "dc_power_out": 19,
     "solar_power_in": 10,
     "power_in": ("total_power_in", 11),
     "power_out": ("total_power_out", 12),
     # TODO: Solar port is broken in underlying library
     # "solar_port": ("status_solar", PortStatus.INPUT),
     "ac_output": ("status_ac_out", PortStatus.NOT_CONNECTED),
+    "dc_output": ("status_dc_out", PortStatus.NOT_CONNECTED),
     "battery_percentage": 13,
 }
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -118,7 +118,7 @@ from . import (
             MOCK_C1000_DETAILS,
             "C1000",
             "dc_output",
-            None,
+            "dc_output",
             "turn_dc_on",
             "turn_dc_off",
             (PortStatus.NOT_CONNECTED, PortStatus.OUTPUT, PortStatus.NOT_CONNECTED),


### PR DESCRIPTION
This PR adds the DC sensors for the C1000X and uses them for the DC output switch.