### PR TITLE
Populate device manufacturer and model

### DIFF
--- a/custom_components/solix_ble/sensor.py
+++ b/custom_components/solix_ble/sensor.py
@@ -1216,6 +1216,8 @@ class SolixSensorEntity(SensorEntity):
         self._attr_device_info = DeviceInfo(
             name=device.name,
             connections={(CONNECTION_BLUETOOTH, device.address)},
+            manufacturer="Anker",
+            model=type(device).__name__,
         )
         self._update_updatable_attributes()
 


### PR DESCRIPTION
## Summary

Every Solix device shows `<unknown>` for **Manufacturer** and **Model** in Home Assistant's device registry, because `DeviceInfo` only sets `name` and `connections`.

This sets:
- `manufacturer="Anker"`
- `model=type(device).__name__` — the device class name, which is the model code (`AS220`, `C1000G2`, `C300`, `F3800`, …)

Using the class name rather than the telemetry-derived `model` string is deliberate: the class name is available immediately at entity init, whereas the telemetry field isn't populated until the first status update (so it would briefly render as "Unknown"). This fixes the display for **all** device types, not just one.

## Testing

Verified live in Home Assistant: the device card now shows **Anker / AS220** instead of `<unknown>` / `<unknown>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WbLpvDpPK2ykge7M5V5ph
